### PR TITLE
Enable publish schedule

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-  # schedule:
-  #   - cron: "0 0 * * *"
+  schedule:
+    - cron: "5 8 * * *"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- set a daily cron job for the publish workflow at 08:05 UTC

## Testing
- `uv tool run ruff format --diff .`
- `uv tool run ruff check .`
- `uv run mypy .`
- `uv tool run ssort .`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862179cfb308326b70dbad5f64783bc