### PR TITLE
Improve export availability checks

### DIFF
--- a/test_tmdb_index.py
+++ b/test_tmdb_index.py
@@ -7,6 +7,8 @@ import pytest
 from tmdb_index import (
     align_id_col,
     change_summary,
+    export_available,
+    export_date,
     fetch_jsonl_gz,
     insert_tmdb_latest_changes,
     tmdb_changes,
@@ -82,6 +84,26 @@ def test_fetch_jsonl_gz_gzip_response() -> None:
 
     assert len(result) == 100
     assert set(result[0]) == {"id", "name"}
+
+
+def test_export_date_before_8am_returns_previous_day() -> None:
+    now = datetime(2024, 1, 2, 7, 59, tzinfo=UTC)
+    assert export_date(now) == date(2024, 1, 1)
+
+
+def test_export_date_after_8am_returns_current_day() -> None:
+    now = datetime(2024, 1, 2, 8, 0, tzinfo=UTC)
+    assert export_date(now) == date(2024, 1, 2)
+
+
+def test_export_available_recent_date_true() -> None:
+    recent = date.today() - timedelta(days=3)
+    assert export_available("movie", recent) is True
+
+
+def test_export_available_old_date_false() -> None:
+    old = date.today() - timedelta(days=365)
+    assert export_available("movie", old) is False
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #7

## Summary
- rename `_export_available` to public `export_available`
- have `_tmdb_raw_export` fallback to yesterday's export
- test new `export_available` behavior for recent and stale dates

## Testing
- `uv tool run ssort .`
- `uv tool run ruff format --diff tmdb_index.py test_tmdb_index.py`
- `uv tool run ruff check .`
- `uv run mypy .`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686219927bf88326b2430d82b2cc8e71